### PR TITLE
Install aws-ofi-nccl plugin to aws-ofi-rccl/lib via make install

### DIFF
--- a/rccl/build_rccl_environment.sh
+++ b/rccl/build_rccl_environment.sh
@@ -65,7 +65,7 @@ echo "============================="
 # Install locations (best-effort paths)
 RCCL_HOME="$BASE_DIR/rccl/build"
 HWLOC_HOME="$BASE_DIR/hwloc"
-AWS_OFI_NCCL_HOME="$BASE_DIR/aws-ofi-nccl/src/.libs"
+AWS_OFI_RCCL_HOME="$BASE_DIR/aws-ofi-rccl"
 RCCL_TESTS_HOME="$BASE_DIR/rccl-tests/build"
 
 cat <<EOF
@@ -118,8 +118,10 @@ fi
 if [ -d "$BASE_DIR/aws-ofi-nccl" ]; then
     pushd "$BASE_DIR/aws-ofi-nccl" && git checkout "v1.18.0" || { echo "Failed to checkout aws-ofi-nccl tag v1.18.0"; popd; exit 1; }
     ./autogen.sh || true
-    CC=gcc ./configure --with-libfabric="$LIBFABRIC_PATH" --with-hwloc="$BASE_DIR" --with-rocm="$ROCM_PATH" || true
+    CC=gcc ./configure --with-libfabric="$LIBFABRIC_PATH" --with-hwloc="$BASE_DIR" --with-rocm="$ROCM_PATH" \
+        --prefix="$AWS_OFI_RCCL_HOME" || true
     make -j"$PARALLELISM" || true
+    make install || true
     popd
 fi
 
@@ -165,7 +167,7 @@ echo "Build completed successfully!"
 echo "============================="
 echo "RCCL_HOME: $RCCL_HOME"
 echo "HWLOC_HOME: $HWLOC_HOME"
-echo "AWS_OFI_NCCL_HOME: $AWS_OFI_NCCL_HOME"
+echo "AWS_OFI_RCCL_HOME: $AWS_OFI_RCCL_HOME"
 echo "RCCL_TESTS_HOME: $RCCL_TESTS_HOME"
 
 echo "To verify installation, inspect the log and built artifacts under $BASE_DIR"


### PR DESCRIPTION
Previously the plugin was left in aws-ofi-nccl/src/.libs, an arbitrary location inside the source tree. Now configure is called with --prefix=$BASE_DIR/aws-ofi-rccl and make install is run, so the plugin lands at aws-ofi-rccl/lib/librccl-net.so — a well-defined, stable path. Rename the tracking variable to AWS_OFI_RCCL_HOME to reflect this.