### PR TITLE
fix: script correctness — shebang placement, paths, flag names, and RCCL build

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,9 +60,11 @@ module load PrgEnv-cray
 module swap cray-mpich cray-mpich-abi
 ```
 
-The scripts can be run with no command line arguments, or one can override the default options:
-`./build_nccl_environment.sh [options]` for NCCL builds
-`./build_rccl_environment.sh [options]` for RCCL builds
+The scripts live in the `nccl/` and `rccl/` subdirectories and can be
+run with no command-line arguments, or with options to override defaults.
+Run them from the directory you want to use as the build base:
+`./nccl/build_nccl_environment.sh [options]` for NCCL builds
+`./rccl/build_rccl_environment.sh [options]` for RCCL builds
 
 ### Options
 
@@ -87,35 +89,35 @@ The scripts can be run with no command line arguments, or one can override the d
 
 1. **Default Build**:
 ```
-./build_nccl_environment.sh
+./nccl/build_nccl_environment.sh
 ```
 
 2. **Custom Build Directory and Parallelism**:
 You can pass a custom build directory and also change the build parallelism (note that there are diminishing marginal returns on increasing the number of build threads)
 ```
-./build_nccl_environment.sh --base-dir /path/to/build/directory --parallelism 32
+./nccl/build_nccl_environment.sh --base-dir /path/to/build/directory --parallelism 32
 ```
 3. **Use Pre-existing Repositories**:
 This option can be leveraged if you are providing your own repositories or don't need to clone the repositories because you already have done so previously.
 ```
-./build_nccl_environment.sh --skip-clone
+./nccl/build_nccl_environment.sh --skip-clone
 ```
 4. **Skip Tests**:
 In case you don't want to clone and build the NCCL or RCCL tests.
 ```
-./build_nccl_environment.sh --skip-tests
+./nccl/build_nccl_environment.sh --skip-tests
 ```
 
 ### RCCL Examples:
 
 1. **Default Build**:
 ```
-./build_rccl_environment.sh
+./rccl/build_rccl_environment.sh
 ```
 
 2. **Custom ROCm Version**:
 ```
-./build_rccl_environment.sh --rccl-version rocm-6.4.0
+./rccl/build_rccl_environment.sh --rccl-version rocm-6.4.0
 ```
 
 ---

--- a/nccl/build_nccl_environment.sh
+++ b/nccl/build_nccl_environment.sh
@@ -1,8 +1,8 @@
+#!/bin/bash
 # SPDX-FileCopyrightText: Copyright Hewlett Packard Enterprise Development LP
 # SPDX-License-Identifier: MIT
 
-#!/bin/bash
-# Hewlett Packard Enterpise 2025
+# Hewlett Packard Enterprise 2025
 # Isa Wazirzada, Ryan Hankins
 set -e
 set -o pipefail

--- a/nccl/nccl_tuning_guide.md
+++ b/nccl/nccl_tuning_guide.md
@@ -74,7 +74,7 @@ Properly configuring Libfabric environment settings is **mandatory** for running
 | `FI_CXI_RDZV_EAGER_SIZE` | `0` | Prevents sending data before the receiver is ready. |
 | `FI_CXI_DEFAULT_TX_SIZE` | `2048` | Should be set especially for large jobs that are dependent on unexpected rendezvous messaging. |
 
-**Note**: To use the `hybrid` rendezvous protocol, the driver property `rdzv_get_en` must be set to `0`. This can be done system-wide by a privileged user or, ideally, on a per-job basis through a job scheduler like Slurm (`--network=disable_rdzv_get`) or PBS Pro (`--disable-rdzv-get`).
+**Note**: To use the `hybrid` rendezvous protocol, the driver property `rdzv_get_en` must be set to `0`. This can be done system-wide by a privileged user or, ideally, on a per-job basis through a job scheduler like Slurm (`--network=disable_rdzv_get`) or PBS Pro (`--disable_rdzv_get`).
 
 -----
 

--- a/rccl/build_rccl_environment.sh
+++ b/rccl/build_rccl_environment.sh
@@ -1,8 +1,8 @@
+#!/bin/bash
 # SPDX-FileCopyrightText: Copyright Hewlett Packard Enterprise Development LP
 # SPDX-License-Identifier: MIT
 
-#!/bin/bash
-# Hewlett Packard Enterpise 2025
+# Hewlett Packard Enterprise 2025
 # Isa Wazirzada, Ryan Hankins
 set -e
 set -o pipefail

--- a/rccl/build_rccl_environment.sh
+++ b/rccl/build_rccl_environment.sh
@@ -12,6 +12,7 @@ BASE_DIR=$(pwd)
 LIBFABRIC_PATH="/opt/cray/libfabric/1.22.0"
 PARALLELISM=16
 ROCM_VERSION="rocm-6.4.0"
+AWS_OFI_NCCL_VERSION="v1.19.0"
 SKIP_CLONE=false
 SKIP_TESTS=false
 LOG_DIR="$BASE_DIR/logs"
@@ -25,6 +26,7 @@ usage() {
     echo "  -l, --libfabric-path <path>   Path to libfabric (default: $LIBFABRIC_PATH)"
     echo "  -p, --parallelism <threads>   Number of threads for parallel builds (default: $PARALLELISM)"
     echo "  -r, --rccl-version <version>  RCCL ROCm version to use (default: $ROCM_VERSION)"
+    echo "  -a, --aws-version <version>   AWS OFI NCCL plugin version to build (default: $AWS_OFI_NCCL_VERSION)"
     echo "  --log-dir <path>              Directory to save the build log file (default: <base-dir>/logs)"
     echo "  --skip-clone                  Skip cloning repositories (use existing directories)"
     echo "  --skip-tests                  Skip building rccl-tests"
@@ -32,7 +34,7 @@ usage() {
     exit 0
 }
 
-ARGS=$(getopt -o b:l:p:r:h --long base-dir:,libfabric-path:,parallelism:,rccl-version:,log-dir:,skip-clone,skip-tests,help -n "$0" -- "$@")
+ARGS=$(getopt -o b:l:p:r:a:h --long base-dir:,libfabric-path:,parallelism:,rccl-version:,aws-version:,log-dir:,skip-clone,skip-tests,help -n "$0" -- "$@")
 if [ $? -ne 0 ]; then usage; fi
 eval set -- "$ARGS"
 
@@ -42,6 +44,7 @@ while true; do
         -l|--libfabric-path) LIBFABRIC_PATH="$2"; shift 2 ;;
         -p|--parallelism) PARALLELISM="$2"; shift 2 ;;
         -r|--rccl-version) ROCM_VERSION="$2"; shift 2 ;;
+        -a|--aws-version) AWS_OFI_NCCL_VERSION="$2"; shift 2 ;;
         --log-dir) LOG_DIR="$2"; shift 2 ;;
         --skip-clone) SKIP_CLONE=true; shift ;;
         --skip-tests) SKIP_TESTS=true; shift ;;
@@ -63,7 +66,7 @@ echo "Build log: $LOG_FILE"
 echo "============================="
 
 # Install locations (best-effort paths)
-RCCL_HOME="$BASE_DIR/rccl/build"
+RCCL_HOME="$BASE_DIR/rccl/build/release"
 HWLOC_HOME="$BASE_DIR/hwloc"
 AWS_OFI_RCCL_HOME="$BASE_DIR/aws-ofi-rccl"
 RCCL_TESTS_HOME="$BASE_DIR/rccl-tests/build"
@@ -76,6 +79,7 @@ Log Directory: $LOG_DIR
 Libfabric Path: $LIBFABRIC_PATH
 Parallelism: $PARALLELISM
 RCCL Version: $ROCM_VERSION
+AWS OFI NCCL Plugin Version: $AWS_OFI_NCCL_VERSION
 Skip Cloning: $SKIP_CLONE
 Skip rccl-tests: $SKIP_TESTS
 =============================
@@ -122,7 +126,7 @@ if [ "$SKIP_CLONE" = false ]; then
     fi
 fi
 if [ -d "$BASE_DIR/aws-ofi-nccl" ]; then
-    pushd "$BASE_DIR/aws-ofi-nccl" && git checkout "v1.19.0" || { echo "Failed to checkout aws-ofi-nccl tag v1.19.0"; popd; exit 1; }
+    pushd "$BASE_DIR/aws-ofi-nccl" && git checkout "$AWS_OFI_NCCL_VERSION" || { echo "Failed to checkout aws-ofi-nccl tag $AWS_OFI_NCCL_VERSION"; popd; exit 1; }
     ./autogen.sh || true
     CC=gcc ./configure --with-libfabric="$LIBFABRIC_PATH" --with-hwloc="$BASE_DIR" --with-rocm="$ROCM_PATH" \
         --prefix="$AWS_OFI_RCCL_HOME" || true
@@ -173,7 +177,8 @@ echo "Build completed successfully!"
 echo "============================="
 echo "RCCL_HOME: $RCCL_HOME"
 echo "HWLOC_HOME: $HWLOC_HOME"
-echo "AWS_OFI_RCCL_HOME: $AWS_OFI_RCCL_HOME"
+echo "AWS_OFI_RCCL_HOME (install prefix): $AWS_OFI_RCCL_HOME"
+echo "  -> add $AWS_OFI_RCCL_HOME/lib to LD_LIBRARY_PATH"
 echo "RCCL_TESTS_HOME: $RCCL_TESTS_HOME"
 
 echo "To verify installation, inspect the log and built artifacts under $BASE_DIR"

--- a/rccl/rccl_tuning_guide.md
+++ b/rccl/rccl_tuning_guide.md
@@ -112,10 +112,10 @@ git checkout v1.19.0
 CC=gcc ./configure \
     --with-libfabric=${LIBFABRIC_PATH} \
     --with-rocm=${ROCM_PATH} \
-    --with-mpi=${MPI_HOME}
-make
+    --with-mpi=${MPI_HOME} \
+    --prefix=${AWS_OFI_PLUGIN_HOME}
+make && make install
 cd ..
-rm -rf aws-ofi-nccl
 
 # Build RCCL Tests
 echo "BUILDING RCCL TESTS"
@@ -133,7 +133,7 @@ At runtime, ensure the compiled plugin (`librccl-net.so`) is in your `LD_LIBRARY
 
 ### Low Performance
 
-1.  **Check if the plugin library is in `LD_LIBRARY_PATH`**. If you see the message `No plugin found (librccl-net.so)`, it means RCCL could not locate the plugin.
+1.  **Check if the plugin library is in `LD_LIBRARY_PATH`**. If you see the message `No plugin found (librccl-net.so)`, it means RCCL could not locate the plugin. Note that some RCCL versions search for `libnccl-net.so` instead of `librccl-net.so`; if the plugin is not found, set `NCCL_NET_PLUGIN` to the explicit path of the `.so` file.
 2.  **Verify the plugin is loaded**. Set `export NCCL_DEBUG=INFO` and look for the log message `Loaded net plugin AWS Libfabric` for all ranks.
 3.  **Confirm GDR is enabled**. Check that `echo $NCCL_NET_GDR_LEVEL` returns `PHB`.
 

--- a/rccl/rccl_tuning_guide.md
+++ b/rccl/rccl_tuning_guide.md
@@ -75,7 +75,7 @@ Properly configuring Libfabric environment settings is **mandatory** for running
 | `FI_CXI_RDZV_EAGER_SIZE` | `0` | Prevents sending data before the receiver is ready. |
 | `FI_CXI_DEFAULT_TX_SIZE` | `2048` | Should be set especially for large jobs that are dependent on unexpected rendezvous messaging. |
 
-**Note**: To use the `hybrid` rendezvous protocol, the driver property `rdzv_get_en` must be set to `0`. This can be done system-wide by a privileged user or, ideally, on a per-job basis through a job scheduler like Slurm (`--network=disable_rdzv_get`) or PBS Pro (`--disable-rdzv-get`).
+**Note**: To use the `hybrid` rendezvous protocol, the driver property `rdzv_get_en` must be set to `0`. This can be done system-wide by a privileged user or, ideally, on a per-job basis through a job scheduler like Slurm (`--network=disable_rdzv_get`) or PBS Pro (`--disable_rdzv_get`).
 
 -----
 


### PR DESCRIPTION
## What and why

This PR fixes five correctness issues in the build scripts and README that would cause immediate failures for a new user following the documentation.

**Changes:**
- Fix script invocation paths in README (missing `nccl/` and `rccl/` subdirectory prefixes in all examples)
- Standardize `--disable_rdzv_get` flag to use underscore in PBS Pro examples in both tuning guides (was inconsistently hyphenated)
- Add missing `--aws-version` / `-a` flag to RCCL build script; fix `RCCL_HOME` path to `rccl/build/release` (was `rccl/build`)
- Fix destructive RCCL manual build example: was `rm -rf aws-ofi-nccl` before install; corrected to `--prefix` + `make install`

These are all correctness fixes — none affect runtime behavior of a correctly-built environment.