### PR TITLE
fix: add FI_CXI_RDZV_GET_MIN=0 to tuning tables and update libfabric version examples

### DIFF
--- a/nccl/nccl_tuning_guide.md
+++ b/nccl/nccl_tuning_guide.md
@@ -72,6 +72,7 @@ Properly configuring Libfabric environment settings is **mandatory** for running
 | `FI_CXI_RDZV_PROTO` | `alt_read` | Use the alt_read rendezvous protocol. |
 | `FI_CXI_RX_MATCH_MODE` | `hybrid` | It allows the network stack to transition to software matching if hardware resources are exhausted. |
 | `FI_CXI_RDZV_EAGER_SIZE` | `0` | Prevents sending data before the receiver is ready. |
+| `FI_CXI_RDZV_GET_MIN` | `0` | Disables the rendezvous get optimization; use with `FI_CXI_RDZV_PROTO=alt_read`. |
 | `FI_CXI_DEFAULT_TX_SIZE` | `2048` | Should be set especially for large jobs that are dependent on unexpected rendezvous messaging. |
 
 **Note**: To use the `hybrid` rendezvous protocol, the driver property `rdzv_get_en` must be set to `0`. This can be done system-wide by a privileged user or, ideally, on a per-job basis through a job scheduler like Slurm (`--network=disable_rdzv_get`) or PBS Pro (`--disable-rdzv-get`).

--- a/nccl/nccl_tuning_guide.md
+++ b/nccl/nccl_tuning_guide.md
@@ -99,7 +99,7 @@ Most CUDA installations include NCCL, so you should use the pre-installed versio
 ```bash
 # Set environment variables for dependencies
 export CUDA_HOME=/usr/local/cuda
-export OFI_HOME=/opt/cray/libfabric/1.15.2.0
+export OFI_HOME=/opt/cray/libfabric/1.22.0
 export AWS_OFI_PLUGIN_HOME=/path/to/install/aws-ofi-plugin
 export HWLOC_PREFIX=`pwd`/hwloc/install
 

--- a/rccl/rccl_tuning_guide.md
+++ b/rccl/rccl_tuning_guide.md
@@ -100,7 +100,7 @@ Most ROCm installations include RCCL, so you should use the pre-installed versio
 ```bash
 # Set environment variables for dependencies
 export ROCM_HOME=/path/to/rocm
-export OFI_HOME=/opt/cray/libfabric/1.15.2.0
+export OFI_HOME=/opt/cray/libfabric/1.22.0
 export MPI_HOME=/opt/cray/pe/mpich/8.1.28/ofi/crayclang/17.0
 export AWS_OFI_PLUGIN_HOME=/path/to/install/aws-ofi-plugin
 

--- a/rccl/rccl_tuning_guide.md
+++ b/rccl/rccl_tuning_guide.md
@@ -73,6 +73,7 @@ Properly configuring Libfabric environment settings is **mandatory** for running
 | `FI_CXI_RDZV_PROTO` | `alt_read` | Use the alt_read rendevous protocool. |
 | `FI_CXI_RX_MATCH_MODE` | `hybrid` | It allows the network stack to transition to software matching if hardware resources are exhausted. |
 | `FI_CXI_RDZV_EAGER_SIZE` | `0` | Prevents sending data before the receiver is ready. |
+| `FI_CXI_RDZV_GET_MIN` | `0` | Disables the rendezvous get optimization; use with `FI_CXI_RDZV_PROTO=alt_read`. |
 | `FI_CXI_DEFAULT_TX_SIZE` | `2048` | Should be set especially for large jobs that are dependent on unexpected rendezvous messaging. |
 
 **Note**: To use the `hybrid` rendezvous protocol, the driver property `rdzv_get_en` must be set to `0`. This can be done system-wide by a privileged user or, ideally, on a per-job basis through a job scheduler like Slurm (`--network=disable_rdzv_get`) or PBS Pro (`--disable-rdzv-get`).


### PR DESCRIPTION
## What and why

This PR fixes two gaps in the environment variable documentation and version references in both tuning guides.

**Changes:**
- Add `FI_CXI_RDZV_GET_MIN=0` to the Essential Libfabric Environment Settings tables in both `nccl_tuning_guide.md` and `rccl_tuning_guide.md` — this variable was already set in `ccl_env.sh` and required for `FI_CXI_RDZV_PROTO=alt_read` to work correctly, but was absent from the documentation tables
- Update the manual build example `OFI_HOME` path from `libfabric/1.15.2.0` to `libfabric/1.22.0` in both guides to match the current default in the build scripts

**Note:** The corresponding fix for `ccl_env.sh` (adding `FI_CXI_RDZV_GET_MIN=0`) was already incorporated upstream in commit 143774876e9 alongside `FI_CXI_RDZV_THRESHOLD=0`.