### PR TITLE
docs: Quick Start section, typo fix, and README clarifications

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,6 +59,7 @@ source ccl_env.sh
 export NCCL_HOME=$(pwd)/nccl/build
 export LD_LIBRARY_PATH=$(pwd)/aws-ofi-nccl/src/.libs:$NCCL_HOME:$LD_LIBRARY_PATH
 cd nccl-tests/build
+# Adjust --ntasks-per-node to match GPUs per node and --cpus-per-task accordingly
 srun --ntasks-per-node=4 --cpus-per-task=72 --network=disable_rdzv_get ./all_reduce_perf -b 8 -e 4G -f 2
 ```
 
@@ -72,6 +73,7 @@ source ccl_env.sh
 export RCCL_HOME=$(pwd)/rccl/build/release
 export LD_LIBRARY_PATH=$(pwd)/aws-ofi-rccl/lib:$RCCL_HOME:$LD_LIBRARY_PATH
 cd rccl-tests/build
+# Adjust --ntasks-per-node to match GPUs per node and --cpus-per-task accordingly
 srun --ntasks-per-node=4 --cpus-per-task=72 --network=disable_rdzv_get ./all_reduce_perf -b 8 -e 4G -f 2
 ```
 
@@ -115,6 +117,17 @@ The scripts can be run with no command line arguments, or one can override the d
 | `--skip-clone`                | Skip cloning repositories (use existing directories)                                         | Disabled                        |
 | `--skip-tests`                | Skip cloning and building tests (NCCL or RCCL)                                         | Disabled                        |
 | `-h, --help`                  | Give a little help                                                                           | N/A                             |
+
+> **Note on `--libfabric-path`:** The default path (`/opt/cray/libfabric/1.22.0`) uses
+> upstream Libfabric versioning. On systems running Cray Slingshot Host Software (SHS),
+> the directory name under `/opt/cray/libfabric/` reflects the **SHS release** rather than
+> the upstream Libfabric version. Run `ls /opt/cray/libfabric/` on your compute node to
+> discover the installed version, then pass it with `-l`. For example, SHS 2.3.1 ships
+> Libfabric 1.29.1 and installs it at `/opt/cray/libfabric/2.3.1`.
+>
+> The build scripts must be executed on a **compute node** (e.g. via `srun --pty bash`
+> or an `sbatch` job), because the required modules (`CUDA_HOME`, `ROCM_PATH`,
+> `MPICH_DIR`) are only available in the compute-node environment.
 
 ---
 
@@ -210,6 +223,8 @@ Setup NCCL - Slingshot variables
 Run NCCL-Tests
 ```
 cd <base-dir>/nccl-tests/build
+# --ntasks-per-node should equal the number of GPUs per node.
+# --cpus-per-task should be total_cpus_per_node / ntasks_per_node.
 srun --ntasks-per-node=4 --cpus-per-task=72 --network=disable_rdzv_get ./all_reduce_perf -b 8 -e 4G -f 2
 ```
 
@@ -264,6 +279,10 @@ Setup RCCL - Slingshot variables
 Run RCCL-Tests
 ```
 cd <base-dir>/rccl-tests/build
+# --ntasks-per-node should equal the number of GPUs per node.
+# --cpus-per-task should be total_cpus_per_node / ntasks_per_node.
+# Ensure the ROCm module matching your build is loaded so that libamdhip64.so
+# and librccl.so are on LD_LIBRARY_PATH (e.g. module load rocm/6.3.3).
 srun --ntasks-per-node=4 --cpus-per-task=72 --network=disable_rdzv_get ./all_reduce_perf -b 8 -e 4G -f 2
 ```
 
@@ -278,6 +297,12 @@ srun --ntasks-per-node=4 --cpus-per-task=72 --network=disable_rdzv_get ./all_red
 
 3. **Build Errors**:
    Review the log file in the log directory for detailed error messages.
+
+4. **`error while loading shared libraries: libamdhip64.so.X: cannot open shared object file`**:
+   The rccl-tests binary was built against a different ROCm major version than the one
+   currently active. Load the ROCm module that matches your build before running the test,
+   e.g. `module load rocm/6.3.3`. If the system default ROCm has been upgraded since you
+   last built, rebuild with the new version using `--rccl-version rocm-<new_version>`.
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -44,6 +44,43 @@ Before using the scripts, ensure the following are installed and available in yo
 
 ---
 
+## Quick Start
+
+> **TL;DR** — clone this repo, load the right modules, run the build script,
+> source `ccl_env.sh`, then launch your test.
+
+**NCCL (NVIDIA GPUs):**
+```bash
+git clone https://github.com/HewlettPackard/shs-ccl-docs.git
+cd shs-ccl-docs
+module load cudatoolkit PrgEnv-cray && module swap cray-mpich cray-mpich-abi
+./nccl/build_nccl_environment.sh          # builds to ./nccl/build, ./aws-ofi-nccl/src/.libs, ./nccl-tests/build
+source ccl_env.sh
+export NCCL_HOME=$(pwd)/nccl/build
+export LD_LIBRARY_PATH=$(pwd)/aws-ofi-nccl/src/.libs:$NCCL_HOME:$LD_LIBRARY_PATH
+cd nccl-tests/build
+srun --ntasks-per-node=4 --cpus-per-task=72 --network=disable_rdzv_get ./all_reduce_perf -b 8 -e 4G -f 2
+```
+
+**RCCL (AMD GPUs):**
+```bash
+git clone https://github.com/HewlettPackard/shs-ccl-docs.git
+cd shs-ccl-docs
+module load rocm PrgEnv-cray && module swap cray-mpich cray-mpich-abi
+./rccl/build_rccl_environment.sh          # builds to ./rccl/build/release, ./aws-ofi-rccl/lib, ./rccl-tests/build
+source ccl_env.sh
+export RCCL_HOME=$(pwd)/rccl/build/release
+export LD_LIBRARY_PATH=$(pwd)/aws-ofi-rccl/lib:$RCCL_HOME:$LD_LIBRARY_PATH
+cd rccl-tests/build
+srun --ntasks-per-node=4 --cpus-per-task=72 --network=disable_rdzv_get ./all_reduce_perf -b 8 -e 4G -f 2
+```
+
+> **Note:** `ccl_env.sh` sets `NCCL_NET`, which forces the network transport.
+> Do **not** source it for single-node Slurm runs — it will cause unnecessary
+> VNI allocation. See [Validation](#validation) for details.
+
+---
+
 ## Usage
 
 ### Pre-Flight Steps - Loading necessary modules (NCCL)

--- a/rccl/rccl_tuning_guide.md
+++ b/rccl/rccl_tuning_guide.md
@@ -70,7 +70,7 @@ Properly configuring Libfabric environment settings is **mandatory** for running
 | `FI_MR_CACHE_MONITOR` | `userfaultfd` | Sets the memory cache monitor to detect changes between virtual and physical memory pages. `kdreg2` is another valid option. |
 | `FI_CXI_DISABLE_HOST_REGISTER` | `1` | Avoids ROCm allocation calls from the provider that may cause RCCL deadlocks. |
 | `FI_CXI_DEFAULT_CQ_SIZE` | `131072` | Should be increased, especially for large jobs. |
-| `FI_CXI_RDZV_PROTO` | `alt_read` | Use the alt_read rendevous protocool. |
+| `FI_CXI_RDZV_PROTO` | `alt_read` | Use the alt_read rendezvous protocol. |
 | `FI_CXI_RX_MATCH_MODE` | `hybrid` | It allows the network stack to transition to software matching if hardware resources are exhausted. |
 | `FI_CXI_RDZV_EAGER_SIZE` | `0` | Prevents sending data before the receiver is ready. |
 | `FI_CXI_DEFAULT_TX_SIZE` | `2048` | Should be set especially for large jobs that are dependent on unexpected rendezvous messaging. |


### PR DESCRIPTION
## What and why

This PR improves documentation usability for new users with three changes.

**Changes:**
- Fix typo in `rccl_tuning_guide.md`: 'rendevous protocool' → 'rendezvous protocol'
- Add a **Quick Start** section to `README.md` with copy-pasteable NCCL and RCCL setup sequences (clone → modules → build script → source env → srun test), so users can get running without reading the full guide
- README clarifications:
  - Note that `--libfabric-path` uses SHS release versioning, not upstream Libfabric versioning (e.g., SHS 2.3.1 → `/opt/cray/libfabric/2.3.1`); instruct users to run `ls /opt/cray/libfabric/` on a compute node to discover their version
  - Note that build scripts must be run on a compute node (`srun --pty bash` or `sbatch`) where CUDA/ROCm/MPICH modules are available
  - Add inline comments explaining that `--ntasks-per-node` should equal GPUs per node and `--cpus-per-task` should equal total CPUs divided by ntasks
  - Add troubleshooting entry for `libamdhip64.so.X: cannot open shared object file` after ROCm upgrades