### PR TITLE
docs: add FI_CXI_RDZV_THRESHOLD=0 to Libfabric env tables in both guides

### DIFF
--- a/nccl/nccl_tuning_guide.md
+++ b/nccl/nccl_tuning_guide.md
@@ -72,6 +72,7 @@ Properly configuring Libfabric environment settings is **mandatory** for running
 | `FI_CXI_RDZV_PROTO` | `alt_read` | Use the alt_read rendezvous protocol. |
 | `FI_CXI_RX_MATCH_MODE` | `hybrid` | It allows the network stack to transition to software matching if hardware resources are exhausted. |
 | `FI_CXI_RDZV_EAGER_SIZE` | `0` | Prevents sending data before the receiver is ready. |
+| `FI_CXI_RDZV_THRESHOLD` | `0` | Sets the message size threshold above which the rendezvous protocol is used; setting to `0` forces all messages through the rendezvous path. |
 | `FI_CXI_RDZV_GET_MIN` | `0` | Disables the rendezvous get optimization; use with `FI_CXI_RDZV_PROTO=alt_read`. |
 | `FI_CXI_DEFAULT_TX_SIZE` | `2048` | Should be set especially for large jobs that are dependent on unexpected rendezvous messaging. |
 

--- a/rccl/rccl_tuning_guide.md
+++ b/rccl/rccl_tuning_guide.md
@@ -73,6 +73,7 @@ Properly configuring Libfabric environment settings is **mandatory** for running
 | `FI_CXI_RDZV_PROTO` | `alt_read` | Use the alt_read rendezvous protocol. |
 | `FI_CXI_RX_MATCH_MODE` | `hybrid` | It allows the network stack to transition to software matching if hardware resources are exhausted. |
 | `FI_CXI_RDZV_EAGER_SIZE` | `0` | Prevents sending data before the receiver is ready. |
+| `FI_CXI_RDZV_THRESHOLD` | `0` | Sets the message size threshold above which the rendezvous protocol is used; setting to `0` forces all messages through the rendezvous path. |
 | `FI_CXI_RDZV_GET_MIN` | `0` | Disables the rendezvous get optimization; use with `FI_CXI_RDZV_PROTO=alt_read`. |
 | `FI_CXI_DEFAULT_TX_SIZE` | `2048` | Should be set especially for large jobs that are dependent on unexpected rendezvous messaging. |
 


### PR DESCRIPTION
FI_CXI_RDZV_THRESHOLD=0 is already set in ccl_env.sh but was missing from the Essential Libfabric Environment Settings tables in both tuning guides. This variable sets the message size threshold above which the rendezvous protocol is used; setting it to 0 forces all messages through the rendezvous path.